### PR TITLE
Fix - Change documentation on how to hide watermark

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There is a default config:
 {
     mac_window_bar = true, -- MacOS style title bar switch
     opacity = true, -- The code snap has some opacity by default, set it to false for 100% opacity 
-    watermark = "CodeSnap.nvim" -- (Optional) you can custom your own watermark, but if you don't like it, just set it to nil
+    watermark = "CodeSnap.nvim" -- (Optional) you can custom your own watermark, but if you don't like it, just set it to ""
 }
 ```
 


### PR DESCRIPTION
In the README it mentions hiding the watermark by setting the value to `nil`. Unfortunately this doesn't work, as when iterating over the configuration, lua will omit any nil values, causing them to not get merged.

Instead, it's possible to remove the watermark by instead setting the value to an empty string `""`. This PR adds in an update to the documentation to reflect that.

See attached screenshots below.

## With nil

![Screenshot from 2024-02-23 21-00-55](https://github.com/mistricky/codesnap.nvim/assets/3148319/b5ba0461-2cb0-4b5f-a7dc-ee679b5348de)

## With empty string

![Screenshot from 2024-02-23 21-01-47](https://github.com/mistricky/codesnap.nvim/assets/3148319/7b20d610-525b-477e-930b-03a6037cdaee)
