### PR TITLE
[Fix] Enable wayland support for arboard

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -9,7 +9,7 @@ tiny-skia = "0.11.4"
 syntect = "5.2.0"
 cosmic-text = "0.11.2"
 serde = "1.0.197"
-arboard = "3.3.2"
+arboard = {features = ["wayland-data-control"], version = "3.3.2"}
 thiserror = "1.0.58"
 regex = "1.10.3"
 


### PR DESCRIPTION
When using this plugin on linux with wayland, copying a snapshot to the clipboard does not seem to work at all. Enabling `wayland-data-control` for `arboard` ([docs](https://github.com/1Password/arboard?tab=readme-ov-file#gnulinux)) fixes that issue and makes the clipboard work as expected under wayland.

But, I'm currently unable to validate that this doesn't break compilation or the clipboard functionality on other platforms. The arboard docs doesn't indicate that it should, but I would make sure to test this on a macbook.