### PR TITLE
[Feat] support RGBA values as background color

### DIFF
--- a/generator/src/color.rs
+++ b/generator/src/color.rs
@@ -1,27 +1,44 @@
 use std::i64;
 use tiny_skia::Color;
 
+const HEX_COLOR_LENGTH: usize = 7;
+const HEX_COLOR_WITH_ALPHA_LENGTH: usize = 9;
+
 pub struct RgbaColor {
     pub color: Color,
 }
 
+pub fn is_valid_hex_color(color: &str) -> bool {
+    (color.len() == HEX_COLOR_LENGTH || color.len() == HEX_COLOR_WITH_ALPHA_LENGTH)
+        && color.starts_with("#")
+}
+
+fn parse_color_to_rgba_hex(hex: &str) -> String {
+    if !is_valid_hex_color(&hex) || hex.len() == HEX_COLOR_WITH_ALPHA_LENGTH {
+        hex.to_string()
+    } else {
+        format!("{}ff", hex)
+    }
+}
+
 impl Into<RgbaColor> for String {
     fn into(self) -> RgbaColor {
-        let hex_color = &self.to_lowercase()[1..self.len()];
+        let rgba_hex_color = parse_color_to_rgba_hex(&self);
+        // Remove the '#' symbol
+        let hex_color = &rgba_hex_color.to_lowercase()[1..rgba_hex_color.len()];
         let chars = hex_color.chars().collect::<Vec<char>>();
         let splits = &chars
             .chunks(2)
             .map(|chunk| i64::from_str_radix(&chunk.iter().collect::<String>(), 16).unwrap())
             .collect::<Vec<_>>();
-        
-        let alpha: i64;
-        match splits.get(3) {
-            Some(x) => alpha = *x,
-            None => alpha = 255,
-        }
 
         RgbaColor {
-            color: Color::from_rgba8(splits[0] as u8, splits[1] as u8, splits[2] as u8, alpha as u8),
+            color: Color::from_rgba8(
+                splits[0] as u8,
+                splits[1] as u8,
+                splits[2] as u8,
+                splits[3] as u8,
+            ),
         }
     }
 }

--- a/generator/src/color.rs
+++ b/generator/src/color.rs
@@ -13,9 +13,15 @@ impl Into<RgbaColor> for String {
             .chunks(2)
             .map(|chunk| i64::from_str_radix(&chunk.iter().collect::<String>(), 16).unwrap())
             .collect::<Vec<_>>();
+        
+        let alpha: i64;
+        match splits.get(3) {
+            Some(x) => alpha = *x,
+            None => alpha = 255,
+        }
 
         RgbaColor {
-            color: Color::from_rgba8(splits[0] as u8, splits[1] as u8, splits[2] as u8, 255),
+            color: Color::from_rgba8(splits[0] as u8, splits[1] as u8, splits[2] as u8, alpha as u8),
         }
     }
 }

--- a/generator/src/components/background.rs
+++ b/generator/src/components/background.rs
@@ -2,16 +2,13 @@ use tiny_skia::{
     Color, GradientStop, LinearGradient, Paint, Pixmap, Point, Rect, SpreadMode, Transform,
 };
 
-use crate::color::RgbaColor;
+use crate::color::{is_valid_hex_color, RgbaColor};
 
 use super::interface::{
     component::{Component, ComponentContext, RenderParams},
     render_error::{self, RenderError},
     style::{ComponentAlign, ComponentStyle, RawComponentStyle},
 };
-
-const HEX_COLOR_LENGTH: usize = 7;
-const HEX_COLOR_WITH_ALPHA_LENGTH: usize = 9;
 
 pub struct Background {
     children: Vec<Box<dyn Component>>,
@@ -21,11 +18,6 @@ impl Background {
     pub fn from_children(children: Vec<Box<dyn Component>>) -> Background {
         Background { children }
     }
-}
-
-fn is_valid_hex_color(color: String) -> bool {
-    (color.len() == HEX_COLOR_LENGTH || color.len() == HEX_COLOR_WITH_ALPHA_LENGTH)
-        && color.starts_with("#")
 }
 
 impl Component for Background {
@@ -52,7 +44,7 @@ impl Component for Background {
         paint.anti_alias = false;
         match params.bg_color.as_ref() {
             Some(color) => {
-                if ! is_valid_hex_color(color.to_string()){
+                if !is_valid_hex_color(color) {
                     return Err(RenderError::InvalidHexColor(color.to_string()));
                 }
 

--- a/generator/src/components/background.rs
+++ b/generator/src/components/background.rs
@@ -11,6 +11,7 @@ use super::interface::{
 };
 
 const HEX_COLOR_LENGTH: usize = 7;
+const HEX_COLOR_WITH_ALPHA_LENGTH: usize = 9;
 
 pub struct Background {
     children: Vec<Box<dyn Component>>,
@@ -20,6 +21,11 @@ impl Background {
     pub fn from_children(children: Vec<Box<dyn Component>>) -> Background {
         Background { children }
     }
+}
+
+fn is_valid_hex_color(color: String) -> bool {
+    (color.len() == HEX_COLOR_LENGTH || color.len() == HEX_COLOR_WITH_ALPHA_LENGTH)
+        && color.starts_with("#")
 }
 
 impl Component for Background {
@@ -46,7 +52,7 @@ impl Component for Background {
         paint.anti_alias = false;
         match params.bg_color.as_ref() {
             Some(color) => {
-                if color.len() != HEX_COLOR_LENGTH || !color.starts_with("#") {
+                if ! is_valid_hex_color(color.to_string()){
                     return Err(RenderError::InvalidHexColor(color.to_string()));
                 }
 


### PR DESCRIPTION
This PR makes sure, that the `bg_color` setting value also supports specifying the alpha channel in the format `#RRGGBBAA`. Omitting the alpha channel value results in the same behaviour as before, so this change should not break any existing configurations.

Codewise, the main change is that i moved the validation of the `bg_color` string into it's own function and added a short snippet to extract the alpha channel value from the `bg_color` or `255` if it's not specified. Let me know if this looks ok style wise, i'm very very new to rust :) 

### examples

* `bg_color = "#000000"`: ![image](https://github.com/mistricky/codesnap.nvim/assets/2656597/88c85888-6ee7-4635-bda1-e29241cd83a5)
* `bg_color = "#00000000"`: ![image](https://github.com/mistricky/codesnap.nvim/assets/2656597/2222358b-e2bb-4e19-9fc8-dfa65cb6b932)
* `bg_color = "#00FF0022"`: ![image](https://github.com/mistricky/codesnap.nvim/assets/2656597/6f052494-d174-4578-9748-aa5040846bc4)

