### PR TITLE
support FreeBSD

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ build:
 	./scripts/apply_generator.sh
 
 build_generator_debug:
-	./scripts/build_generator.sh	
+	./scripts/build_generator.sh
 
 build_generator:
 	./scripts/build_generator.sh --release

--- a/scripts/apply_generator.sh
+++ b/scripts/apply_generator.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source ./scripts/check_os.sh
 
 function apply_generator {

--- a/scripts/build_generator.sh
+++ b/scripts/build_generator.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source ./scripts/check_os.sh
 
 (cd ./generator; cargo build $1)

--- a/scripts/check_os.sh
+++ b/scripts/check_os.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 os="Unknown"
 uname_output=`uname`
 
@@ -9,7 +10,17 @@ if [[ $uname_output == "Darwin" ]]; then
   elif [[ $uname_m_output == "x86_64" ]]; then
      os="mac-x86_64"
   else
-    echo "Unknown sillicon"
+    echo "Unknown silicon"
+  fi
+elif [[ $uname_output == "FreeBSD" ]]; then
+  uname_m_output=`uname -m`
+
+  if [[ $uname_m_output == "arm64" ]]; then
+     os="freebsd-aarch64"
+  elif [[ $uname_m_output == "amd64" ]]; then
+     os="freebsd-x86_64"
+  else
+    echo "Unknown silicon"
   fi
 elif [[ $uname_output == "Linux" ]]; then
   os="linux-x86_64"


### PR DESCRIPTION
I did this in line with the existing code for simplicity

- scripts are bash style, not posix shell, so make this explicit
- trim up trailing whitespace
- add FreeBSD architecture support

I think there may be simpler / cleaner ways to accommodate this
overall approach but this seems a good start.

Testing was done with:

```NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1699801871
```

![snap](https://github.com/mistricky/codesnap.nvim/assets/284368/07a46298-e111-4439-8ed2-292e308167da)
