### PR TITLE
[fix] add shebang for portability

### DIFF
--- a/scripts/apply_generator.sh
+++ b/scripts/apply_generator.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source ./scripts/check_os.sh
 
 function apply_generator {

--- a/scripts/build_generator.sh
+++ b/scripts/build_generator.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source ./scripts/check_os.sh
 
 (cd ./generator; cargo build $1)


### PR DESCRIPTION
I could not build from `make` or `make build_generator`, and I figured out there were missing shebang in script files. I did not put shebang to `check_os.sh` since it is only sourced from other scripts.