### PR TITLE
replace shebang with Nix compatible version

### DIFF
--- a/scripts/apply_generator.sh
+++ b/scripts/apply_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source ./scripts/check_os.sh
 

--- a/scripts/build_generator.sh
+++ b/scripts/build_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source ./scripts/check_os.sh
 


### PR DESCRIPTION
Hi,
really like this little tool. I had to replace the shebang for these two scripts to make them run on Nix. 

This makes them more portable in general and is supposed to be good practice even if you're on  another distro, so I think it's a good idea to make this the default.

Thanks for codesnap!

Edit: Well, I should have checked before. Seems like this is covered by #58. I'll leave it open for now as my PR more minimal, but I think it can be closed.