### PR TITLE
[Feat] use auto-generate filename when the filename is not specified

### DIFF
--- a/lua/codesnap/config.lua
+++ b/lua/codesnap/config.lua
@@ -32,6 +32,24 @@ local function parse_extension(specify_extension)
     or parse_file_extension_by_highlighting_file_presets(filename, file_extension)
 end
 
+-- Auto generated codesnap filename based on the following rule:
+-- CodeSnap_y-m-d_at_h:m:s
+local function auto_generate_snap_filename()
+  return os.date("CodeSnap_%Y-%m-%d_at_%H:%M:%S.png")
+end
+
+-- If the save_path is already configured, but no explicit filename is specified,
+-- it will be replaced with auto-generated filename
+local function parse_save_path(save_path)
+  if save_path == nil or string_utils.ends_with(save_path, "png") then
+    return save_path
+  end
+
+  local parsed_save_path = string_utils.ends_with(save_path, "/") and save_path or save_path .. "/"
+
+  return parsed_save_path .. auto_generate_snap_filename()
+end
+
 function config_module.get_config(specify_extension)
   local code = visual_utils.get_selected_text()
   local extension = specify_extension or parse_extension(specify_extension)
@@ -45,7 +63,7 @@ function config_module.get_config(specify_extension)
     error("Cannot detect current filetype", 0)
   end
 
-  return table_utils.merge({
+  local config = table_utils.merge({
     code = code,
     extension = extension,
     fonts_folder = assets_folder .. "/fonts",
@@ -53,6 +71,10 @@ function config_module.get_config(specify_extension)
     theme = "base16-onedark",
     file_path = static.config.has_breadcrumbs and path_utils.get_relative_path() or "",
   }, static.config)
+
+  config.save_path = parse_save_path(config.save_path)
+
+  return config
 end
 
 return config_module

--- a/lua/codesnap/config.lua
+++ b/lua/codesnap/config.lua
@@ -2,7 +2,6 @@ local visual_utils = require("codesnap.utils.visual")
 local path_utils = require("codesnap.utils.path")
 local string_utils = require("codesnap.utils.string")
 local static = require("codesnap.static")
-local list_utils = require("codesnap.utils.list")
 local table_utils = require("codesnap.utils.table")
 local config_module = {}
 

--- a/lua/codesnap/init.lua
+++ b/lua/codesnap/init.lua
@@ -26,9 +26,17 @@ function main.save_snapshot(extension)
     )
   end
 
-  require("generator").save_snapshot(config_module.get_config(extension))
+  local matched_extension = string.match(static.config.save_path, "%.(.+)$")
+
+  if matched_extension ~= "png" and matched_extension ~= nil then
+    error("The extension of save_path should be .png", 0)
+  end
+
+  local config = config_module.get_config(extension)
+
+  require("generator").save_snapshot(config)
   vim.cmd("delmarks <>")
-  vim.notify("Save snapshot in " .. static.config.save_path .. " successfully")
+  vim.notify("Save snapshot in " .. config.save_path .. " successfully")
 end
 
 return main


### PR DESCRIPTION
When the filename of save_path is not specified, for instance:
```lua
save_path = "~/Pictures/"
-- or
save_path = "~/Pictures"
``` 

The filename will be replaced with an auto-generate filename based on the `CodeSnap_y-m-d_at_h:m:s` rule.

Which means after snapshot, the file will be save in `~/Pictures/CodeSnap_y-m-d_at_h:m:s.png`