### PR TITLE
[Fix] replace all tab characters with space for correct render text

### DIFF
--- a/generator/src/code.rs
+++ b/generator/src/code.rs
@@ -11,7 +11,7 @@ fn min_width(width: f32) -> f32 {
 }
 
 pub fn calc_wh(text: &str, char_wdith: f32, line_height: f32) -> (f32, f32) {
-    let trimmed_text = trim_space(text);
+    let trimmed_text = prepare_code(text);
     let lines = trimmed_text.lines();
     let max_length_line = lines.clone().into_iter().fold("", |max_length_line, cur| {
         if cur.len() > max_length_line.len() {
@@ -26,7 +26,16 @@ pub fn calc_wh(text: &str, char_wdith: f32, line_height: f32) -> (f32, f32) {
     (min_width(width), height)
 }
 
-pub fn trim_space(text: &str) -> String {
+// The tab character is incorrectly render using cosmic, need to replace all tab with space
+// before render the code
+fn replace_tab_to_space(text: &str) -> String {
+    let spaces = " ".repeat(2);
+
+    str::replace(text, "\t", &spaces)
+}
+
+// If the first line have indention, remove the same indention from subsequent lines
+fn trim_space(text: &str) -> String {
     let lines = text.split("\n").collect::<Vec<&str>>();
     let first_line = lines.first().unwrap();
     let head_spaces = Regex::new(r"^(\s*)").unwrap().find(first_line);
@@ -46,4 +55,8 @@ pub fn trim_space(text: &str) -> String {
         }
         None => text.to_string(),
     }
+}
+
+pub fn prepare_code(code: &str) -> String {
+    replace_tab_to_space(&trim_space(&code))
 }

--- a/generator/src/components/editor/code.rs
+++ b/generator/src/components/editor/code.rs
@@ -1,5 +1,5 @@
 use crate::{
-    code::{calc_wh, trim_space},
+    code::{calc_wh, prepare_code},
     components::interface::{
         component::{Component, ComponentContext, RenderParams},
         render_error,
@@ -71,7 +71,7 @@ impl Component for Code {
 impl Code {
     pub fn new(value: String, line_height: f32, font_size: f32) -> Code {
         Code {
-            value: trim_space(&value),
+            value: prepare_code(&value),
             line_height,
             font_size,
             children: vec![],


### PR DESCRIPTION
- Replace all tab characters with space for correct render text
- Add comments to code process functions