### PR TITLE
feat: Default to `XDG_PICTURES_DIR` for save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ There is a default config:
     min_width = 0,
     bg_x_padding = 122,
     bg_y_padding = 82,
+    save_path = os.getenv("XDG_PICTURES_DIR") or (os.getenv("HOME").. "/Pictures")
 }
 ```
 

--- a/lua/codesnap/static.lua
+++ b/lua/codesnap/static.lua
@@ -1,4 +1,15 @@
 local path_utils = require("codesnap.utils.path")
+-- Get user os
+-- If linux, use XDG_PICTURE_DIR, if mac use ~/Pictures, if windows use FOLDERID_Pictures (If support is added back)
+local default_save_path = nil
+local os_name = vim.loop.os_uname().sysname
+if os_name == "Linux" then
+  default_save_path = os.getenv("XDG_PICTURES_DIR") or (os.getenv("HOME") .. "/Pictures")
+elseif os_name == "Darwin" then
+  default_save_path = os.getenv("HOME") .. "/Pictures"
+else
+  error("codesnap.nvim only supports Linux and MacOS")
+end
 
 return {
   config = {
@@ -15,6 +26,7 @@ return {
     min_width = 0,
     bg_x_padding = 122,
     bg_y_padding = 82,
+    save_path = default_save_path,
   },
   cwd = path_utils.back(path_utils.back(debug.getinfo(1, "S").source:sub(2):match("(.*[/\\])"))),
   preview_switch = true,


### PR DESCRIPTION
@mistricky  I think this is a better, more saner default were we default to the `xdg_pictures_dir` or `/Users/<Username>/Pictures` on mac. Let me know what you think. I tried to update the docs where applicable, not sure if more is required. 