### PR TITLE
fix: Not loading system fonts by default

### DIFF
--- a/generator/src/text.rs
+++ b/generator/src/text.rs
@@ -20,6 +20,7 @@ impl FontRenderer {
         let mut font_system = FontSystem::new();
 
         font_system.db_mut().load_fonts_dir(fonts_folder);
+        font_system.db_mut().load_system_fonts();
 
         let metrics = Metrics::new(font_size, line_height).scale(scale_factor.clone());
 


### PR DESCRIPTION
closes https://github.com/mistricky/codesnap.nvim/issues/145
According to my quick investigation the codesnap simply does not loading system fonts using the current configuration, I might be wrong but this should make it actually load system fonts at least on macos 