### PR TITLE
Refresh default config and highlight APIs

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -60,7 +60,7 @@ fn save(_: &Lua, (file_path, config): (String, SnapshotConfigLua)) -> LuaResult<
     let snapshot_type: SnapshotType = Path::new(&file_path)
         .extension()
         .and_then(OsStr::to_str)
-        .ok_or_else(|| mlua::Error::RuntimeError("Invalid file extension".to_string()))?
+        .unwrap_or("png")
         .to_string()
         .into();
 

--- a/lua/codesnap/static.lua
+++ b/lua/codesnap/static.lua
@@ -29,6 +29,7 @@ return {
           color = "#ffffff",
           font_family = "Pacifico",
         },
+        radius = 12,
       },
       themes_folders = {},
       fonts_folders = {},


### PR DESCRIPTION
This PR refreshes CodeSnap’s default configuration and docs while rounding out the highlight feature set and tidying supporting workflows.

- expose `parse_code_theme` and new highlight helpers for snapshot theming
- add highlight snapshot support and README updates for the v2 flow
- clean up Lua sources with stylua and ignore vendored libraries
- streamline release/build workflows and dependency handling (PAT usage, OpenSSL install, warning cleanup)
- update the default configuration for the production-ready release

**Testing**: Not covered
