### PR TITLE
fix: correctly expand root in `themes_folders` and `font_folders`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,31 +275,31 @@ Above code will generate a solid white background.
 CodeSnap.nvim use gradient background by default, you can specify the gradient colors by setting `background.stops` to a table of colors, for example:
 
 ```lua
-"background": {
-    "start": {
-      "x": 0,
-      "y": 0
+background = {
+    start = {
+      x = 0,
+      y = 0
     },
-    "end": {
-      "x": "max",
-      "y": "max"
+    end = {
+      x = "max",
+      y = "max"
     },
-    "stops": [
+    stops = [
       {
-        "position": 0,
-        "color": "#EBECB2"
+        position = 0,
+        color = "#EBECB2"
       },
       {
-        "position": 0.28,
-        "color": "#F3B0F7"
+        position = 0.28,
+        color = "#F3B0F7"
       },
       {
-        "position": 0.73,
-        "color": "#92B5F0"
+        position = 0.73,
+        color = "#92B5F0"
       },
       {
-        "position": 0.94,
-        "color": "#AEF0F8"
+        position = 0.94,
+        color = "#AEF0F8"
       }
     ]
 }

--- a/lua/codesnap/init.lua
+++ b/lua/codesnap/init.lua
@@ -3,6 +3,7 @@ local table_utils = require("codesnap.utils.table")
 local module = require("codesnap.module")
 local config_module = require("codesnap.config")
 local modal = require("codesnap.modal")
+local path = require("codesnap.path")
 
 -- Prepare the path of the Rust module
 -- Try to fetch pre-built library first, then fallback to development build
@@ -15,6 +16,9 @@ local main = {
 
 function main.setup(config)
   static.config = table_utils.merge_config(static.config, config == nil and {} or config)
+  if static.config.snapshot_config then
+    path.expand_paths_in_config(static.config.snapshot_config)
+  end
 end
 
 -- Save snapshot to specified save_path

--- a/lua/codesnap/path.lua
+++ b/lua/codesnap/path.lua
@@ -1,0 +1,25 @@
+local path_module = {}
+
+local function expand_path(path)
+  if type(path) ~= "string" then
+    return path
+  end
+  if path:sub(1, 1) == "~" then
+    local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
+    return home .. path:sub(2)
+  end
+  return path
+end
+
+function path_module.expand_paths_in_config(config)
+  if config.themes_folders and #config.themes_folders > 0 then
+    config.themes_folders = vim.tbl_map(expand_path, config.themes_folders)
+  end
+
+  if config.fonts_folders and #config.fonts_folders > 0 then
+    config.fonts_folders = vim.tbl_map(expand_path, config.fonts_folders)
+  end
+  return config
+end
+
+return path_module

--- a/lua/codesnap/utils/table.lua
+++ b/lua/codesnap/utils/table.lua
@@ -35,6 +35,11 @@ function table_utils.merge_config(t1, t2)
       t1[k] = t2[k]
     end
   end
+  for k, v in pairs(t2) do
+    if t1[k] == nil and v ~= nil then
+      t1[k] = v
+    end
+  end
 
   return t1
 end


### PR DESCRIPTION
## Description

v2 of this great plugin introduced the option to use custom themes with `themes_folders` and the name of the theme in `theme`. Sadly it didn't work as expected as the config returned a `nil` value. 

I did some digging and was able to identify two issues:

- The paths are not expanded correctly and the rust binding was unable to identify the folder location
- If the user defined config has a key which the default does not have, it will not be added to the static config

This PR fixes both issues by expanding the paths and adding the key of the user config to the static config if the default does not have said key.

Along the way, I also noticed a small syntax error in the readme which I also fixed

Closes #172 
Closes #169 
maybe related to #171 
