### PR TITLE
feat: add Nix flake for reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,35 @@ We recommend using [Lazy.nvim](https://github.com/folke/lazy.nvim) to install Co
 
 > Maybe you are CodeSnap.nvim v1 user, you may notice that we remove the `build` option in v2, because we don't need to compile the Rust code anymore, we precompiled the `generator` shared file for common platforms, you can find the precompiled files in [releases](https://github.com/mistricky/codesnap.nvim/releases) page. So when you first install v2, CodeSnap.nvim will download the precompiled file automatically, it may take a few seconds to download the file, please be patient.
 
+### Nix (flake)
+
+CodeSnap.nvim is already packaged in [nixpkgs](https://search.nixos.org/packages?query=codesnap-nvim) as `vimPlugins.codesnap-nvim` — for most Nix users that's the easiest way to install it.
+
+This flake is intended for when you'd rather **build from source** (e.g. to track `main`, a fork, or a specific commit). It builds the plugin together with the `generator` library from source, so there's no runtime download and everything is reproducible. This is handy for Home Manager or any Nix-based Neovim setup.
+
+Expose the plugin as a flake input:
+
+```nix
+{
+  inputs.codesnap.url = "github:mistricky/codesnap.nvim";
+}
+```
+
+Then use `codesnap.packages.${system}.default` as a start plugin. For example, with Home Manager:
+
+```nix
+programs.neovim = {
+  enable = true;
+  plugins = [inputs.codesnap.packages.${pkgs.system}.default];
+};
+```
+
+The flake also exposes:
+
+- `packages.${system}.generator` — just the Rust `generator` cdylib.
+- `checks.${system}.plugin-loads` — a headless-Neovim smoke test that loads the plugin and native library (`nix flake check`).
+- `devShells.${system}.default` — a Rust + stylua dev shell for hacking on the generator.
+
 
 ## Keymappings
 TODO

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,157 @@
+{
+  description = "CodeSnap.nvim - pretty code snapshots for Neovim";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    # Systems for which the generator is compiled and the plugin is provided.
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs systems (system:
+        f {
+          inherit system;
+          pkgs = import nixpkgs {inherit system;};
+        });
+
+    # Plugin version, read from project.toml so it stays in sync with releases.
+    version = let
+      toml = builtins.readFile ./project.toml;
+      m = builtins.match ".*version[[:space:]]*=[[:space:]]*\"([^\"]+)\".*" toml;
+    in
+      if m == null
+      then "0.0.0"
+      else builtins.head m;
+  in {
+    # The Rust `generator` crate, built as a native Lua module (cdylib).
+    packages = forAllSystems ({
+      pkgs,
+      system,
+    }: let
+      inherit (pkgs) lib stdenv;
+
+      generator = pkgs.rustPlatform.buildRustPackage {
+        pname = "codesnap-generator";
+        inherit version;
+        src = self;
+        sourceRoot = "${self.sourceInfo.name or "source"}/generator";
+        cargoLock.lockFile = ./generator/Cargo.lock;
+
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.rustPlatform.bindgenHook
+        ];
+
+        buildInputs = [
+          pkgs.libuv.dev
+          pkgs.openssl
+        ];
+
+        env = {
+          # Use the system OpenSSL rather than the vendored copy pinned in
+          # generator/Cargo.toml (vendoring is only needed for cross-compiled
+          # release binaries, not for a native Nix build).
+          OPENSSL_NO_VENDOR = 1;
+
+          # On Darwin, undefined symbols are resolved at load time against
+          # Neovim's LuaJIT runtime.
+          RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+        };
+
+        doCheck = false;
+      };
+
+      libExt =
+        if stdenv.hostPlatform.isDarwin
+        then "dylib"
+        else "so";
+
+      # The <os>-<arch>_generator.<ext> name that lua/codesnap/fetch.lua
+      # (get_platform_lib_name) looks for in the libs directory.
+      libName = let
+        osArch =
+          {
+            "x86_64-linux" = "linux-x86_64";
+            "aarch64-linux" = "linux-aarch64";
+            "x86_64-darwin" = "mac-x86_64";
+            "aarch64-darwin" = "mac-aarch64";
+          }.${
+            system
+          };
+      in "${osArch}_generator.${libExt}";
+
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "codesnap.nvim";
+        inherit version;
+        src = self;
+        doCheck = false;
+
+        # Provision the Nix-built generator where the runtime loader expects
+        # a pre-built library (lua/libs/<os>-<arch>_generator.<ext>), plus the
+        # matching .version marker. With both present, lua/codesnap/fetch.lua
+        # uses the library directly and never attempts a GitHub release
+        # download at runtime.
+        postInstall = ''
+          mkdir -p $out/lua/libs
+          ln -s ${generator}/lib/libgenerator.${libExt} $out/lua/libs/${libName}
+          printf '%s' "${version}" > $out/lua/libs/.version
+        '';
+      };
+    in {
+      inherit generator;
+      default = plugin;
+    });
+
+    # `nix flake check` builds the plugin and asserts that Neovim can require
+    # the plugin and successfully load the native generator module.
+    checks = forAllSystems ({
+      pkgs,
+      system,
+    }: {
+      plugin-loads = let
+        plugin = self.packages.${system}.default;
+        nvim = pkgs.neovim;
+      in
+        pkgs.runCommand "codesnap-plugin-loads" {
+          nativeBuildInputs = [nvim];
+        } ''
+          export HOME=$TMPDIR
+          nvim --headless --clean \
+            --cmd "set runtimepath^=${plugin}" \
+            -c "lua require('codesnap').setup({})" \
+            -c "lua assert(require('codesnap.module').load_generator() ~= nil, 'generator failed to load')" \
+            -c "qa!" 2> $TMPDIR/err || (cat $TMPDIR/err; exit 1)
+          echo "codesnap.nvim loaded and generator module resolved" > $out
+        '';
+    });
+
+    devShells = forAllSystems ({
+      pkgs,
+      system,
+    }: {
+      default = pkgs.mkShell {
+        inputsFrom = [self.packages.${system}.generator];
+        packages = with pkgs; [
+          cargo
+          rustc
+          rust-analyzer
+          rustfmt
+          clippy
+          stylua
+        ];
+      };
+    });
+
+    formatter = forAllSystems ({pkgs, ...}: pkgs.alejandra);
+  };
+}


### PR DESCRIPTION
Add a flake that builds the plugin together with the generator library from source, so Nix users don't need a runtime binary download or a custom out-of-tree derivation.
