### PR TITLE
[Fix] Windows Path Parsing Failure Check & [Chore] Updated Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Configuration is **completely different** between v1 and v2, which is following 
 current config looks like.
 
 #### Windows Support
-We are excited to announce that CodeSnap.nvim now supports Windows! 🎉, but we don't have enough time to test it on Windows, so if you find any issues on Windows, please let us know by creating an issue.
+We are excited to announce that CodeSnap.nvim now supports Windows! 🎉 It is less tested than it could be, so if you find any issues on Windows, please let us know by creating an issue.
 
-## Prerequirements
+## Prerequisites
 - Neovim 0.9.0+
 
 ## Installation
@@ -107,7 +107,7 @@ We recommend using [Lazy.nvim](https://github.com/folke/lazy.nvim) to install Co
 
 **Lazy.nvim**
 ```lua
-{ "mistricky/codesnap.nvim", tag = "v2.0.0" }
+{ "mistricky/codesnap.nvim", tag = "v2.0.5" }
 ```
 
 > Maybe you are CodeSnap.nvim v1 user, you may notice that we remove the `build` option in v2, because we don't need to compile the Rust code anymore, we precompiled the `generator` shared file for common platforms, you can find the precompiled files in [releases](https://github.com/mistricky/codesnap.nvim/releases) page. So when you first install v2, CodeSnap.nvim will download the precompiled file automatically, it may take a few seconds to download the file, please be patient.

--- a/lua/codesnap/utils/path.lua
+++ b/lua/codesnap/utils/path.lua
@@ -20,7 +20,7 @@ function path_utils.dir_name()
   local src_path = debug.getinfo(1).source
   local retval = src_path:match(pattern)
 
-  -- if regex has no matches fails and you're on non-unix-style system (windows), try again w/Unix-Style path sep
+  -- if regex has no matches (fails) and you're on non-unix-style system (windows), try again w/Unix-Style path sep
   if (retval == nil) and (sep ~= fallback_sep) then
     local new_pattern = "@?(.*" .. vim.pesc(fallback_sep) .. ")"
     retval = src_path:match(new_pattern)

--- a/lua/codesnap/utils/path.lua
+++ b/lua/codesnap/utils/path.lua
@@ -14,9 +14,23 @@ function path_utils.join(separator, ...)
 end
 
 function path_utils.dir_name()
+  local fallback_sep = "/"
   local sep = path_utils.get_separator()
   local pattern = "@?(.*" .. vim.pesc(sep) .. ")"
-  return debug.getinfo(1).source:match(pattern)
+  local src_path = debug.getinfo(1).source
+  local retval = src_path:match(pattern)
+
+  -- if regex has no matches fails and you're on non-unix-style system (windows), try again w/Unix-Style path sep
+  if (retval == nil) and (sep ~= fallback_sep) then
+    local new_pattern = "@?(.*" .. vim.pesc(fallback_sep) .. ")"
+    retval = src_path:match(new_pattern)
+  end
+
+  if retval == nil then
+    error("CodeSnap config cannot determine runtime path.", 2)
+  end
+
+  return retval
 end
 
 function path_utils.with_dir_name(path)


### PR DESCRIPTION
Fixes issue #181 with path parsing on windows.
Updated recommended plugin version in readme to match version listed in repo.
Changed wording in readme about testing on Windows as there has now been a little.
Changed `Prerequirements` to `Prerequisites` in docs.