### PR TITLE
fix: load generator
  library explicitly via package.loadlib

### DIFF
--- a/lua/codesnap/module.lua
+++ b/lua/codesnap/module.lua
@@ -46,10 +46,14 @@ end
 function module.load_generator(is_debug)
   local generator_path = module.generator_file_path(is_debug)
 
-  package.cpath = path_utils.join(";", package.cpath, generator_path)
-
   if module.generator == nil then
-    module.generator = require("generator")
+    local loader = package.loadlib(generator_path, "luaopen_generator")
+
+    if not loader then
+      error("Failed to load generator: " .. generator_path)
+    end
+
+    module.generator = loader()
   end
 
   return module.generator


### PR DESCRIPTION
## Problem

The generator library is loaded like this:

```lua
package.cpath = path_utils.join(";", package.cpath, generator_path)
module.generator = require("generator")
```

This relies on `require` resolving the generic module name `generator`
against the global `package.cpath`:

- `generator` is a very generic name. Any other `generator.so`,
  `generator.lua`, or `generator/` directory earlier on the runtime path
  will silently shadow the intended library.
- It permanently mutates the global `package.cpath` just to perform a
  one-time load.
- When loading fails, the error is the generic `error loading module
  'generator'`, which gives no hint about which file is missing or how to
  fix it.

## Reproduction environment

- OS: CachyOS (Arch Linux based, x86_64)
- Desktop session: KDE Plasma on Wayland
- Neovim: v0.12.4
- Distribution: LazyVim, plugin installed via lazy.nvim
- Plugin version observed: v2.0.0, verified against v2.0.5 / current main

The failure was hit while running `:CodeSnap` under this setup. After the
library was present and loadable, the snapshot worked, but any problem with
the library location produced only the unhelpful `error loading module
'generator'` message, with no indication of which file Neovim was looking
for.

## Fix

Load the exact library path with `package.loadlib`:

```lua
local loader = package.loadlib(generator_path, "luaopen_generator")

if not loader then
  error("Failed to load generator: " .. generator_path)
end

module.generator = loader()
```

- The path and symbol are explicit, so there is no name resolution or
  shadowing.
- No global state is mutated.
- Failures raise an actionable error that includes the exact path.

Behavior is otherwise unchanged: the module instance is still cached in
`module.generator`, and the pre-built / debug library lookup in
`module.generator_file_path` is untouched.
