### PR TITLE
fix: replace deprecated Neovim APIs

### DIFF
--- a/lua/codesnap/fetch.lua
+++ b/lua/codesnap/fetch.lua
@@ -1,7 +1,8 @@
 local fetch = {}
+local uv = vim.uv or vim.loop
 
 local function get_os_arch()
-  local uname = vim.loop.os_uname()
+  local uname = uv.os_uname()
   local os_name = uname.sysname:lower()
   local arch = uname.machine:lower()
 

--- a/lua/codesnap/highlight.lua
+++ b/lua/codesnap/highlight.lua
@@ -36,8 +36,8 @@ function highlight_module.create_highlight_selector_window(cb_name, code)
     title_pos = "center",
   })
 
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", vim.bo.filetype)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("filetype", vim.bo.filetype, { buf = bufnr })
   vim.api.nvim_buf_set_keymap(bufnr, "n", "q", ":q<CR>", {})
   vim.api.nvim_buf_set_keymap(bufnr, "", "<ESC>", ":q<CR>", {})
   vim.keymap.set(

--- a/lua/codesnap/modal.lua
+++ b/lua/codesnap/modal.lua
@@ -21,13 +21,13 @@ function M.pop_modal(selected_text, filetype, callback)
 
   -- Set filetype for syntax highlighting if provided
   if filetype and filetype ~= "" then
-    vim.api.nvim_buf_set_option(buf, "filetype", filetype)
+    vim.api.nvim_set_option_value("filetype", filetype, { buf = buf })
   end
 
   -- Make the buffer read-only
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
-  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
-  vim.api.nvim_buf_set_option(buf, "readonly", true)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+  vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+  vim.api.nvim_set_option_value("readonly", true, { buf = buf })
 
   -- Calculate window size and position
   local width = 0
@@ -57,9 +57,9 @@ function M.pop_modal(selected_text, filetype, callback)
   })
 
   -- Set window options
-  vim.api.nvim_win_set_option(win, "cursorline", true)
-  vim.api.nvim_win_set_option(win, "number", true)
-  vim.api.nvim_win_set_option(win, "relativenumber", false)
+  vim.api.nvim_set_option_value("cursorline", true, { win = win })
+  vim.api.nvim_set_option_value("number", true, { win = win })
+  vim.api.nvim_set_option_value("relativenumber", false, { win = win })
 
   -- Ensure the window has focus
   vim.api.nvim_set_current_win(win)

--- a/lua/codesnap/utils/platform.lua
+++ b/lua/codesnap/utils/platform.lua
@@ -1,6 +1,7 @@
 local platform_utils = {}
+local uv = vim.uv or vim.loop
 
-local current_os_name = vim.loop.os_uname().sysname
+local current_os_name = uv.os_uname().sysname
 
 function platform_utils.match_os(matches_table)
   local fn = matches_table[current_os_name]


### PR DESCRIPTION
## Summary

Replace deprecated libuv and option APIs.

## Why

[Neovim 0.10 deprecates `vim.loop` and the buffer/window-specific option setters](https://neovim.io/doc/user/deprecated/#deprecated-0.10).

## What changed

- Use a Neovim 0.9-compatible libuv binding.
- Set buffer and window options with explicit targets.

## Testing

- `nix flake check`
- StyLua on the changed files
- Headless module-load smoke test

## Related Issue(s)

None.
